### PR TITLE
Prevent any caching for health controller

### DIFF
--- a/src/controllers/LivenessController.php
+++ b/src/controllers/LivenessController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Health Check plugin for Craft CMS 3.x
  *
@@ -57,11 +58,17 @@ class LivenessController extends Controller
      */
     public function actionIndex()
     {
+        $response = Craft::$app->getResponse();
+
+        $response
+            ->getHeaders()
+            ->set('Cache-Control', 'no-cache, no-store, must-revalidate');
+
         if (Craft::$app->db->isActive) {
             return $this->asJson(['message' => 'ok']);
         }
 
-        Craft::$app->getResponse()->setStatusCode(400);
+        $response->setStatusCode(400);
 
         return $this->asErrorJson('could not establish connection to database');
     }


### PR DESCRIPTION
You never want a health check to be cached, so this helps enforce that.

For example, suppose you're running Varnish. The no-cache header will tell Varnish or any other caching mechanism to never cache.